### PR TITLE
Fix state persistence on page unload

### DIFF
--- a/script.js
+++ b/script.js
@@ -424,6 +424,8 @@ function initializeCustomerPaymentVisibility() {
 }
 
 // Clean up on page unload
+// Previously this removed the saved state, which prevented session persistence.
+// Removing the localStorage.clear ensures the bill data remains after reloads.
 window.addEventListener('unload', () => {
-  localStorage.removeItem(APP_STATE_KEY);
+  saveState();
 });


### PR DESCRIPTION
## Summary
- ensure bill data persists by saving state instead of clearing it on unload

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_684f84a0de44832ea0cf5985934d2309