### PR TITLE
Fix manifest icon reference

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,9 +7,9 @@
   "background_color": "#ffffff",
   "icons": [
     {
-      "src": "assets/icon-192.png",
+      "src": "assets/logo.svg",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/svg+xml"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- reference `logo.svg` in the PWA manifest

## Testing
- `node -e "const m=require('./manifest.json'); console.log(m.icons);"`
- `curl -I https://example.com`

------
https://chatgpt.com/codex/tasks/task_b_68517d40dddc832e88810caf051f6430