### PR TITLE
Add calc module and tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,6 +111,7 @@
   <script src="https://cdn.jsdelivr.net/npm/@szmarczak/interact.js@1.4.11/dist/interact.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/gsap.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/ScrambleTextPlugin.min.js" defer></script>
+  <script src="src/calc.js"></script>
   <script src="script.js" defer></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "tinh_bill",
+  "version": "1.0.0",
+  "description": "",
+  "main": "script.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/script.js
+++ b/script.js
@@ -15,14 +15,7 @@ const themeColor = document.getElementById('theme-color');
 const customerPayInput = document.getElementById('customerPay');
 const changeDisplay = document.getElementById('change');
 
-// Price constants
-const PRICES = {
-  thit: 11000,
-  banhMiMat: 6000,
-  nemNuong: 7000,
-  nuoc: 10000,
-  banhMiThitBase: 3000
-};
+// Price constants are provided by calc.js
 
 // State management
 let lastClearedData = null;
@@ -164,30 +157,14 @@ function calculateTotal() {
   const banhMiThit = parseInt(banhMiThitInput.value) || 0;
   const soThitBanhMi = parseInt(soThitBanhMiInput.value) || 1;
 
-  let total = 0;
-  const subtotals = [];
-
-  // Calculate individual totals
-  const thitSubtotal = thit * PRICES.thit;
-  if (thit > 0) subtotals.push({ label: 'Thịt', value: thitSubtotal });
-
-  const banhMiMatSubtotal = banhMiMat * PRICES.banhMiMat;
-  if (banhMiMat > 0) subtotals.push({ label: 'Bánh mì mật', value: banhMiMatSubtotal });
-
-  const nemNuongSubtotal = nemNuong * PRICES.nemNuong;
-  if (nemNuong > 0) subtotals.push({ label: 'Nem nướng', value: nemNuongSubtotal });
-
-  const nuocSubtotal = nuoc * PRICES.nuoc;
-  if (nuoc > 0) subtotals.push({ label: 'Nước', value: nuocSubtotal });
-
-  const banhMiThitSubtotal = banhMiThit * (PRICES.banhMiThitBase + ((soThitBanhMi - 1) * PRICES.thit));
-  if (banhMiThit > 0) {
-    let label = 'Bánh mì kẹp thịt';
-    if (soThitBanhMi > 1) label += ` (${soThitBanhMi} thịt/bánh)`;
-    subtotals.push({ label, value: banhMiThitSubtotal });
-  }
-
-  total = thitSubtotal + banhMiMatSubtotal + nemNuongSubtotal + nuocSubtotal + banhMiThitSubtotal;
+  const { total, subtotals } = calculateTotals({
+    thit,
+    banhMiMat,
+    nemNuong,
+    nuoc,
+    banhMiThit,
+    soThitBanhMi
+  });
 
   // Show/hide soThitBanhMi section
   if (banhMiThit > 0) {

--- a/src/calc.js
+++ b/src/calc.js
@@ -1,0 +1,44 @@
+const PRICES = {
+  thit: 11000,
+  banhMiMat: 6000,
+  nemNuong: 7000,
+  nuoc: 10000,
+  banhMiThitBase: 3000
+};
+
+function calculateTotals({
+  thit = 0,
+  banhMiMat = 0,
+  nemNuong = 0,
+  nuoc = 0,
+  banhMiThit = 0,
+  soThitBanhMi = 1
+} = {}) {
+  const thitSubtotal = thit * PRICES.thit;
+  const banhMiMatSubtotal = banhMiMat * PRICES.banhMiMat;
+  const nemNuongSubtotal = nemNuong * PRICES.nemNuong;
+  const nuocSubtotal = nuoc * PRICES.nuoc;
+  const banhMiThitSubtotal = banhMiThit * (PRICES.banhMiThitBase + ((soThitBanhMi - 1) * PRICES.thit));
+
+  const subtotals = [];
+  if (thit > 0) subtotals.push({ label: 'Thịt', value: thitSubtotal });
+  if (banhMiMat > 0) subtotals.push({ label: 'Bánh mì mật', value: banhMiMatSubtotal });
+  if (nemNuong > 0) subtotals.push({ label: 'Nem nướng', value: nemNuongSubtotal });
+  if (nuoc > 0) subtotals.push({ label: 'Nước', value: nuocSubtotal });
+  if (banhMiThit > 0) {
+    let label = 'Bánh mì kẹp thịt';
+    if (soThitBanhMi > 1) label += ` (${soThitBanhMi} thịt/bánh)`;
+    subtotals.push({ label, value: banhMiThitSubtotal });
+  }
+
+  const total = thitSubtotal + banhMiMatSubtotal + nemNuongSubtotal + nuocSubtotal + banhMiThitSubtotal;
+  return { total, subtotals };
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { PRICES, calculateTotals };
+} else {
+  // expose globally for browser usage
+  window.PRICES = PRICES;
+  window.calculateTotals = calculateTotals;
+}

--- a/tests/calc.test.js
+++ b/tests/calc.test.js
@@ -1,0 +1,27 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { calculateTotals } = require('../src/calc');
+
+test('returns zero for no items', () => {
+  const result = calculateTotals({});
+  assert.strictEqual(result.total, 0);
+  assert.deepStrictEqual(result.subtotals, []);
+});
+
+test('calculates totals for multiple items', () => {
+  const result = calculateTotals({ thit: 2, banhMiMat: 1, nemNuong: 3 });
+  assert.strictEqual(result.total, 49000);
+  assert.deepStrictEqual(result.subtotals, [
+    { label: 'Thịt', value: 22000 },
+    { label: 'Bánh mì mật', value: 6000 },
+    { label: 'Nem nướng', value: 21000 }
+  ]);
+});
+
+test('handles banh mi thit with extra meat', () => {
+  const result = calculateTotals({ banhMiThit: 2, soThitBanhMi: 3 });
+  assert.strictEqual(result.total, 50000);
+  assert.deepStrictEqual(result.subtotals, [
+    { label: 'Bánh mì kẹp thịt (3 thịt/bánh)', value: 50000 }
+  ]);
+});


### PR DESCRIPTION
## Summary
- extract total calculation into `src/calc.js`
- update `script.js` to use the new pure function
- include `src/calc.js` in `index.html`
- add a Node-based test suite
- configure npm test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68517d3f2c20832e90a127c0522462b3